### PR TITLE
Bugfix/L9-start

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,7 +28,7 @@ const app = Vue.createApp({
             return this.variants[this.selectedVariant].image
         },
         inStock() {
-            return this.variants[this.selectedVariant].image
+            return this.variants[this.selectedVariant].quantity
         }
     }
 })


### PR DESCRIPTION
#### Changes

The method `inStock` was defined as it follows in `L9-start` branch:

```js
inStock() {
            return this.variants[this.selectedVariant].image
        }
```

There was a small issue with this definition causing the `Add to Cart` button to not change `disabled` property.
 